### PR TITLE
Local Server - Add support for Optional Heading

### DIFF
--- a/code/sim/utils/sim_utils.py
+++ b/code/sim/utils/sim_utils.py
@@ -56,9 +56,10 @@ def traj2control(plan_traj, info):
         x to right, y to forward and z to upward
     """
     plan_traj_stats = np.zeros((plan_traj.shape[0]+1, 5))
-    if plan_traj.shape[1] > 2:
+    plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]
+    if plan_traj.shape[1] == 4:
         # Use heading if provided.
-        plan_traj_stats[1:, :3] = plan_traj[:, [1,0,2]]
+        plan_traj_stats[1:, 2] = plan_traj[:, 2]
     else:
         # If heading is not provided, use the waypoints to compute heading.
         plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]

--- a/code/sim/utils/sim_utils.py
+++ b/code/sim/utils/sim_utils.py
@@ -56,11 +56,16 @@ def traj2control(plan_traj, info):
         x to right, y to forward and z to upward
     """
     plan_traj_stats = np.zeros((plan_traj.shape[0]+1, 5))
-    plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]
-    prev_a, prev_b = 0, 0
-    for i, (a, b) in enumerate(plan_traj):
-        rot = np.arctan((b - prev_b)/(a - prev_a))
-        plan_traj_stats[i+1, 2] = rot
+    if plan_traj.shape[1] > 2:
+        # Use heading if provided.
+        plan_traj_stats[1:, :3] = plan_traj[:, [1,0,2]]
+    else:
+        # If heading is not provided, use the waypoints to compute heading.
+        plan_traj_stats[1:, :2] = plan_traj[:, [1,0]]
+        prev_a, prev_b = 0, 0
+        for i, (a, b) in enumerate(plan_traj):
+            rot = np.arctan((b - prev_b)/(a - prev_a))
+            plan_traj_stats[i+1, 2] = rot
     curr_stat = np.array(
         [0, 0, 0, info['ego_velo'], info['ego_steer']]
     )

--- a/docker/web_server_dockerfile
+++ b/docker/web_server_dockerfile
@@ -50,15 +50,18 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && rm -f Miniconda3-latest-Linux-x86_64.sh
 ENV PATH /app/miniconda/bin:$PATH
 
+RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
+RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
+
 RUN conda create -p /app/env -y python=3.11
 
 SHELL ["conda", "run","--no-capture-output", "-p","/app/env", "/bin/bash", "-c"]
 
 COPY --chown=1000:1000 . /app/
 
-ENV TCNN_CUDA_ARCHITECTURES 75
+ENV TCNN_CUDA_ARCHITECTURES 89
 
-ENV TORCH_CUDA_ARCH_LIST "7.5"
+ENV TORCH_CUDA_ARCH_LIST "8.9"
 
 RUN curl -fsSL https://pixi.sh/install.sh | sh
 


### PR DESCRIPTION
This PR adds support for headings to be passed to the `execute_action()` method of `EnvHandler` in addition to the (x, y) waypoints. If the heading exists (assumed 3rd column of `plan_traj` array), it is used, else the heading is calculated using the waypoints as done before. Note that this change is non-breaking and will work with the previously expected trajectory format.